### PR TITLE
Fix FDS instrument lag on playback and WAV export

### DIFF
--- a/Source/ChannelsFDS.cpp
+++ b/Source/ChannelsFDS.cpp
@@ -294,7 +294,7 @@ void CChannelHandlerFDS::FillWaveRAM(const char *pBuffer)		// // //
 		WriteRegister(0x4089, 0x80);
 
 		// This is the time the loop takes in NSF code
-		AddCycles(1088);
+		AddCycles(960);
 
 		// Wave ram
 		for (int i = 0; i < 0x40; ++i)

--- a/Source/SeqInstHandlerFDS.cpp
+++ b/Source/SeqInstHandlerFDS.cpp
@@ -44,7 +44,7 @@ void CSeqInstHandlerFDS::TriggerInstrument()
 {
 	CSeqInstHandler::TriggerInstrument();
 
-	CChannelHandlerInterfaceFDS *pInterface = dynamic_cast<CChannelHandlerInterfaceFDS*>(m_pInterface);
+	auto *pInterface = dynamic_cast<CChannelHandlerInterfaceFDS*>(m_pInterface);
 	if (pInterface == nullptr) return;
 	auto pFDSInst = std::dynamic_pointer_cast<const CInstrumentFDS>(m_pInstrument);
 	if (pFDSInst == nullptr) return;
@@ -58,14 +58,13 @@ void CSeqInstHandlerFDS::UpdateInstrument()
 {
 	CSeqInstHandler::UpdateInstrument();
 	
-	if (auto pInterface = dynamic_cast<CChannelHandlerInterfaceFDS*>(m_pInterface))
-		if (auto pFDSInst = std::dynamic_pointer_cast<const CInstrumentFDS>(m_pInstrument))
-			UpdateTables(pFDSInst.get());
+	if (auto pFDSInst = std::dynamic_pointer_cast<const CInstrumentFDS>(m_pInstrument))
+		UpdateTables(pFDSInst.get());
 }
 
 void CSeqInstHandlerFDS::UpdateTables(const CInstrumentFDS *pInst)
 {
-	CChannelHandlerInterfaceFDS *pInterface = dynamic_cast<CChannelHandlerInterfaceFDS*>(m_pInterface);
+	auto *pInterface = dynamic_cast<CChannelHandlerInterfaceFDS*>(m_pInterface);
 	if (pInterface == nullptr) return;
 	char Buffer[0x40];		// // //
 	for (int i = 0; i < 0x40; i++)

--- a/Source/SeqInstHandlerFDS.cpp
+++ b/Source/SeqInstHandlerFDS.cpp
@@ -35,7 +35,7 @@
 void CSeqInstHandlerFDS::LoadInstrument(std::shared_ptr<CInstrument> pInst)		// // //
 {
 	CSeqInstHandler::LoadInstrument(pInst);
-	
+
 	if (auto pFDSInst = std::dynamic_pointer_cast<const CInstrumentFDS>(m_pInstrument))
 		UpdateTables(pFDSInst.get());
 }
@@ -43,7 +43,7 @@ void CSeqInstHandlerFDS::LoadInstrument(std::shared_ptr<CInstrument> pInst)		// 
 void CSeqInstHandlerFDS::TriggerInstrument()
 {
 	CSeqInstHandler::TriggerInstrument();
-	
+
 	CChannelHandlerInterfaceFDS *pInterface = dynamic_cast<CChannelHandlerInterfaceFDS*>(m_pInterface);
 	if (pInterface == nullptr) return;
 	auto pFDSInst = std::dynamic_pointer_cast<const CInstrumentFDS>(m_pInstrument);

--- a/Source/SoundGen.h
+++ b/Source/SoundGen.h
@@ -183,6 +183,8 @@ public:
 	void		 WriteAPU(int Address, char Value);
 
 	// Used by channels
+
+	/** Add cycles to model execution time (capped at vblank). */
 	void		AddCycles(int Count);
 
 	// Other


### PR DESCRIPTION
- Update FDS wave writing duration from 1088 to 960 cycles
- Fix bug where FDS wave writing creates lag
    - Keep track of emulated delays occurring outside CSoundGen::UpdateAPU()
    - Truncate CSoundGen::AddCycles(int Count) to vblank.