### PR TITLE
Wine speed hack [do not merge]

### DIFF
--- a/Source/FamiTracker.cpp
+++ b/Source/FamiTracker.cpp
@@ -766,6 +766,7 @@ static std::map<LONG, int> counts;
 
 BOOL CFamiTrackerApp::OnIdle(LONG lCount)		// // //
 {
+	// The default implementation of this member function frees temporary objects and unused dynamic link libraries from memory.
 	counts[lCount]++;
 
 	const auto t = cr::floor<cr::seconds>(clk::now());
@@ -780,8 +781,8 @@ BOOL CFamiTrackerApp::OnIdle(LONG lCount)		// // //
 		counts.clear();
 	}
 
-	if (CWinApp::OnIdle(lCount))
-		return TRUE;
+//	if (CWinApp::OnIdle(lCount))
+//		return TRUE;
 
 	if (m_bVersionReady && !m_pVersionMessage.IsEmpty()) {
 		m_bVersionReady = false;

--- a/Source/FamiTracker.cpp
+++ b/Source/FamiTracker.cpp
@@ -42,6 +42,11 @@
 #include "WinInet.h"		// // //
 #pragma comment(lib, "wininet.lib")
 
+#include <iostream>
+#include <chrono>
+#include <map>
+
+
 // Single instance-stuff
 const TCHAR FT_SHARED_MUTEX_NAME[]	= _T("FamiTrackerMutex");	// Name of global mutex
 const TCHAR FT_SHARED_MEM_NAME[]	= _T("FamiTrackerWnd");		// Name of global memory area
@@ -752,8 +757,29 @@ void CFamiTrackerApp::ReloadColorScheme()
 	}
 }
 
+
+namespace cr = std::chrono;
+using clk = cr::steady_clock;
+
+static cr::time_point<clk> prevTime;
+static std::map<LONG, int> counts;
+
 BOOL CFamiTrackerApp::OnIdle(LONG lCount)		// // //
 {
+	counts[lCount]++;
+
+	const auto t = cr::floor<cr::seconds>(clk::now());
+	if (t > prevTime) {
+		prevTime = t;
+
+		std::cerr << "CFamiTrackerApp::OnIdle called times:\n";
+		for (const auto& kv : counts) {
+			std::cerr << kv.first << " called times= " << kv.second << std::endl;
+		}
+		std::cerr << std::endl;
+		counts.clear();
+	}
+
 	if (CWinApp::OnIdle(lCount))
 		return TRUE;
 

--- a/Source/FamiTrackerView.cpp
+++ b/Source/FamiTrackerView.cpp
@@ -131,7 +131,7 @@ const int SINGLE_STEP = 1;				// Size of single step moves (default: 1)
 
 // Timer IDs
 enum { 
-	TMR_UPDATE,
+	TMR_UPDATE = 1,	// timer IDs should be nonzero
 	TMR_SCROLL
 };
 

--- a/Source/FamiTrackerView.cpp
+++ b/Source/FamiTrackerView.cpp
@@ -49,6 +49,9 @@
 
 #include <cmath>
 #include <assert.h>
+#include <iostream>
+#include <chrono>
+#include <map>
 
 using std::get_if;
 
@@ -818,12 +821,32 @@ void CFamiTrackerView::OnSetFocus(CWnd* pOldWnd)
 	InvalidateCursor();
 }
 
+namespace cr = std::chrono;
+using clk = cr::steady_clock;
+
+static cr::time_point<clk> prevTime;
+static std::map<UINT_PTR, int> counts;
+
 void CFamiTrackerView::OnTimer(UINT_PTR nIDEvent)
 {
+	counts[nIDEvent]++;
+
+	const auto t = cr::floor<cr::seconds>(clk::now() - cr::milliseconds(100));
+	if (t > prevTime) {
+		prevTime = t;
+
+		std::cerr << "CFamiTrackerView::OnTimer called times:\n";
+		for (const auto& kv : counts) {
+			std::cerr << kv.first << " called times= " << kv.second << std::endl;
+		}
+		std::cerr << std::endl;
+		counts.clear();
+	}
+
 	// Timer callback function
 	switch (nIDEvent) {
 		// Drawing updates when playing
-		case TMR_UPDATE: 
+		case TMR_UPDATE:
 			PeriodicUpdate();
 			break;
 

--- a/Source/FamiTrackerView.cpp
+++ b/Source/FamiTrackerView.cpp
@@ -859,7 +859,7 @@ void CFamiTrackerView::OnTimer(UINT_PTR nIDEvent)
 			break;
 	}
 
-	CView::OnTimer(nIDEvent);
+//	CView::OnTimer(nIDEvent);
 }
 
 void CFamiTrackerView::PeriodicUpdate()


### PR DESCRIPTION
Don't call `CView::OnTimer` and `CWinApp::OnIdle` (which take too much CPU time on Wine).