### PR TITLE
Removed 'Transpose Song' instrument check

### DIFF
--- a/Source/TransposeDlg.cpp
+++ b/Source/TransposeDlg.cpp
@@ -67,7 +67,6 @@ void CTransposeDlg::Transpose(int Trsp, unsigned int Track)
 		if (Type == CHANID_NOISE || Type == CHANID_DPCM) continue;
 		for (int p = 0; p < MAX_PATTERN; ++p) for (int r = 0; r < MAX_PATTERN_LENGTH; ++r) {
 			m_pDocument->GetDataAtPattern(Track, p, c, r, &Note);
-			if (Note.Instrument == MAX_INSTRUMENTS || Note.Instrument == HOLD_INSTRUMENT) continue;
 			if (Note.Note >= NOTE_C && Note.Note <= NOTE_B && !s_bDisableInst[Note.Instrument]) {
 				int MIDI = MIDI_NOTE(Note.Octave, Note.Note) + Trsp;
 				if (MIDI < 0) MIDI = 0;


### PR DESCRIPTION
The 'Transpose Song' function checks if a note is attached to an instrument before attempting to transpose it, meaning that notes on rows with no instrument data (or with the legato ('&&') instrument) would not be transposed. Since I couldn't think of any instances where this check was actually necessary (and I *did* think of 2 instances where the check obstructed the function's purpose), I removed it.